### PR TITLE
WEB-4923 - 23958 - Mudar URL do CE para emitir notas no server do RS

### DIFF
--- a/storage/autorizadores.json
+++ b/storage/autorizadores.json
@@ -5,7 +5,7 @@
         "AM": "AM",
         "AP": "SVRS",
         "BA": "SVRS",
-        "CE": "CE",
+        "CE": "SVRS",
         "DF": "SVRS",
         "ES": "SVRS",
         "GO": "GO",


### PR DESCRIPTION
[//]: # (jira: "{"IssueId":"23245","UpdatedAt":"2025-06-24T17:13:45.534-0300"}")

> [!NOTE]
> Card: <https://zucchettibr.atlassian.net/browse/WEB-4923> - 23958 - Mudar URL do CE para emitir notas no server do RS
> Autor: @giovannidalbello

## Descrição
<p>Conforme combinado mudar no CE para os server do RS</p>

<p><a href="http://nfce.sefaz.ce.gov.br/pages/informacoes/web_services.jsf" class="external-link" rel="nofollow noreferrer">http://nfce.sefaz.ce.gov.br/pages/informacoes/web_services.jsf</a><br/>
<a href="https://nfce.svrs.rs.gov.br/ws/NfeAutorizacao/NFeAutorizacao4.asmx" class="external-link" rel="nofollow noreferrer">https://nfce.svrs.rs.gov.br/ws/NfeAutorizacao/NFeAutorizacao4.asmx</a></p>

<p>para dia 01/07 conforme comunicado <br/>
<a href="https://prnt.sc/pG__rm9iFSI9" class="external-link" rel="nofollow noreferrer">https://prnt.sc/pG__rm9iFSI9</a></p>

<p>Olhar isso<br/>
<a href="https://github.com/nfephp-org/sped-nfe/commit/f1604e9a6e6af2e6962b2ac115fff5abfc9b55ba" class="external-link" rel="nofollow noreferrer">https://github.com/nfephp-org/sped-nfe/commit/f1604e9a6e6af2e6962b2ac115fff5abfc9b55ba</a></p>

## Nota técnica do desenvolvedor
<div class="panel" style="background-color: #e3fcef;border-width: 1px;"><div class="panelContent" style="background-color: #e3fcef;">
<p><b>Solução:</b></p>

<p>Implementado para qu eo estado do CE utilize o mesmo provedor do RS. Conforme o commit <a href="https://github.com/nfephp-org/sped-nfe/commit/f1604e9a6e6af2e6962b2ac115fff5abfc9b55ba" title="smart-link" class="external-link" rel="nofollow noreferrer">https://github.com/nfephp-org/sped-nfe/commit/f1604e9a6e6af2e6962b2ac115fff5abfc9b55ba</a> </p>
</div></div>

<div class="panel" style="background-color: #fffae6;border-width: 1px;"><div class="panelContent" style="background-color: #fffae6;">
<p><b>Impacto da Solução:</b></p>

<p>A alteração impacta diretamente na emissão de NFC-e no estado do CE. Neste caso sugiro testar emissão de NFC-e para a UF de CE.</p>

<p>Ao testar rodar um cpf-docker / composer install no backend. </p>
</div></div>